### PR TITLE
chore(mise): explicitely set pyproject.toml as ruff config

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -19,8 +19,8 @@ run = "uv export --format requirements-txt --no-hashes --no-header --no-dev --no
 description = "Lint & format (fix by default)"
 alias = "f"
 run = [
-    "uv run ruff check --fix --unsafe-fixes .",
-    "uv run ruff format ."
+  "uv run ruff format . --config pyproject.toml",
+  "uv run ruff check --fix --unsafe-fixes . --config pyproject.toml",
 ]
 
 [tasks.mypy]


### PR DESCRIPTION
This pull request updates the linting and formatting task configuration to ensure that both `ruff format` and `ruff check` explicitly use the `pyproject.toml` configuration file.

Linting and formatting configuration updates:

* Updated the `mise.toml` task for linting and formatting to pass the `--config pyproject.toml` flag to both `ruff format` and `ruff check`, ensuring consistent configuration usage.

NOTE to self: The check can fail and prevent subsequent commands from running, so we introduce it later