### PR TITLE
fix(ruff): import hashlib to satisfy lint checks

### DIFF
--- a/megaloader/plugins/fanbox.py
+++ b/megaloader/plugins/fanbox.py
@@ -1,4 +1,5 @@
 import contextlib
+import hashlib
 import logging
 import os
 import re


### PR DESCRIPTION
This pull request introduces a minor update to the `megaloader/plugins/fanbox.py` file by adding an import for the `hashlib` module.

```
mise run fix
[fix] $ uv run ruff format . --config pyproject.toml
15 files left unchanged
[fix] $ uv run ruff check --fix --unsafe-fixes . --config pyproject.toml
All checks passed!
```