### PR TITLE
fix(mypy): ensure file URL is a string when joining with BASE_URL

### DIFF
--- a/megaloader/plugins/cyberdrop.py
+++ b/megaloader/plugins/cyberdrop.py
@@ -118,7 +118,7 @@ class Cyberdrop(BasePlugin):
 
         logger.info(f"Found {len(file_links)} files in album. Fetching metadata...")
         for link in file_links:
-            file_url = urljoin(self.BASE_URL, link["href"])
+            file_url = urljoin(self.BASE_URL, str(link["href"]))
             file_id_match = re.search(r"/f/(\w+)", file_url)
             if not file_id_match:
                 continue


### PR DESCRIPTION
This pull request makes a minor update to the `megaloader/plugins/cyberdrop.py` plugin to ensure compatibility when constructing file URLs. The change explicitly converts `link["href"]` to a string before joining it with the base URL, which helps prevent potential type errors.

- Explicitly cast `link["href"]` to a string in the URL construction within the `_export_album` method to avoid type issues.