### PR TITLE
docs: add .env.example with setup instructions for Pixiv, Fanbox, and Rule34

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,44 @@
+# Need help? Open an issue:
+# https://github.com/totallynotdavid/megaloader/issues
+#
+# Copy this file to a new .env file and fill in your credentials.
+# You can also run:
+# > cp .env.example .env
+#
+# Then replace the placeholders with your actual values.
+# All credentials are optional, modules will work without them,
+# but content access will be limited.
+
+# === Pixiv ===
+# To get your PHPSESSID:
+# 1. Log into Pixiv (pixiv.net)
+# 2. Open browser developer tools (F12)
+# 3. Go to Application > Cookies
+# 4. Find the cookie named "PHPSESSID"
+# 5. Copy its value (format: 12345678_ABCDEFGHIJKLMNOPQRSTUVWXYZ123456)
+PIXIV_PHPSESSID=
+
+# === Fanbox ===
+# To get your FANBOXSESSID:
+# 1. Log into Fanbox (fanbox.cc)
+# 2. Open browser developer tools (F12)
+# 3. Go to Application > Cookies
+# 4. Find the cookie named "FANBOXSESSID"
+# 5. Copy its value (format: 12345678_ABCDEFGHIJKLMNOPQRSTUVWXYZ123456)
+FANBOX_SESSION_ID=
+
+# Note: Session tokens may not provide access to all public content.
+# Pixiv generally works more reliably than Fanbox for this purpose.
+
+# === Rule34.xxx ===
+# To get your API credentials:
+# 1. Go to https://rule34.xxx/index.php?page=account&s=home
+# 2. Log into your account
+# 3. Go to https://rule34.xxx/index.php?page=account&s=options
+# 4. Find your User ID and API Key in the API Access Credentials section
+#    The URL will contain parameters like:
+#    &api_key=YOUR_API_KEY_HERE&user_id=YOUR_USER_ID_HERE
+#    Extract the values from these URL parameters
+#    If your api_key appears empty, click 'Generate New Key'
+RULE34_USER_ID=
+RULE34_API_KEY=


### PR DESCRIPTION
This patch introduces a .env.example file to improve onboarding and configuration.
It provides step-by-step instructions for obtaining and setting up optional credentials:

* PIXIV_PHPSESSID for Pixiv
* FANBOX_SESSION_ID for Fanbox
* RULE34_USER_ID and RULE34_API_KEY for Rule34.xxx