### PR TITLE
ci: limit CodeQL and security runs to Python changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,9 +3,12 @@ name: CodeQL
 on:
     push:
         branches: ["main"]
+        paths: ['**/*.py']
     pull_request:
+        branches: ["main"]
+        paths: ['**/*.py']
     schedule:
-        - cron: "32 16 * * 3"
+        - cron: "0 5 * * 3"
     workflow_dispatch:
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,11 +1,9 @@
-name: Security Report
+name: security report
 
 on:
     push:
-        branches:
-            - main
-        paths:
-            - "megaloader/**"
+        branches: ["main"]
+        paths: ['**/*.py']
     workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This patch updates the GitHub Actions workflows for CodeQL analysis and security reporting to improve efficiency and consistency.

Changes include:

* CodeQL analysis (.github/workflows/codeql.yml):
  * Restrict triggers to pushes/PRs affecting Python files (**/*.py)
  * Reschedule weekly run to 05:00 UTC on Wednesdays

* Security report (.github/workflows/security.yml):
  * Rename workflow to lowercase for consistency
  * Restrict triggers to pushes on main affecting Python files