### PR TITLE
docs: rewrite README with modern install guides, and detailed usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,11 @@ to fix issues caused by changes made by the supported sites.
 
 The
 [original implementation](https://github.com/totallynotdavid/megaloader/tree/9adeffe2d4055d26f9db2b7fcbf6f92de0aca628)
-served as inspiration, but the current codebase has been mostly rebuilt from the
-ground up. Development priorities focus on four core platforms (Bunkr,
-PixelDrain, Cyberdrop, and GoFile) while maintaining best-effort support for
-extended platforms.
+served as inspiration, but the current codebase has been
+[mostly rebuilt from the ground up](https://github.com/totallynotdavid/megaloader/graphs/contributors).
+Development priorities focus on four core platforms (Bunkr, PixelDrain,
+Cyberdrop, and GoFile) while maintaining best-effort support for extended
+platforms.
 
 <!-- prettier-ignore -->
 > [!TIP]

--- a/README.md
+++ b/README.md
@@ -369,5 +369,4 @@ For **feature requests**, submit through GitHub Issues with their respective use
 cases, supported platforms, example URLs, and workflow explanations.
 
 For **general questions**, use GitHub Discussions for questions about usage,
-architecture, or integration. This helps build a knowledge base for the
-community.
+architecture, or integration.

--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ platforms are maintained on a best-effort basis.
 
 ## Installation
 
-Python 3.10 or newer is required, though [I recommend](mise.toml?plain=1#L5) Python 3.13 or
-higher for reproducibility. The installation process varies depending on your
-preferred dependency management approach.
+Python 3.10 or newer is required, though [I recommend](mise.toml?plain=1#L5)
+Python 3.13 or higher for reproducibility. The installation process varies
+depending on your preferred dependency management approach.
 
 Begin by cloning the repository to your local machine:
 
@@ -89,8 +89,8 @@ Standard pip installation
 </summary>
 
 For users familiar with traditional Python package management, install
-dependencies directly from the requirements file. This method works across all
-Python environments and doesn't require additional tooling.
+dependencies directly from the requirements.txt file. This method works across
+all Python environments and doesn't require additional tooling.
 
 On macOS/Linux:
 

--- a/README.md
+++ b/README.md
@@ -309,8 +309,9 @@ will partially pass the automated checks.
 
 New platform plugins should follow established patterns for consistency and
 maintainability. The basic structure requires inheriting from `BasePlugin` and
-implementing the two core methods, with registration in the domain registry for
-automatic URL detection.
+implementing the two core methods, with registration in the
+[domain registry](megaloader/plugins/__init__.py?plain=1#L16) for automatic URL
+detection.
 
 ```python
 class NewPlatformPlugin(BasePlugin):

--- a/README.md
+++ b/README.md
@@ -332,9 +332,8 @@ class NewPlatformPlugin(BasePlugin):
         return True
 ```
 
-<!-- prettier-ignore -->
 Register your plugin in the domain mapping located in
-[megaloader/plugins/__init__.py](megaloader/plugins/__init__.py) to enable
+[`megaloader/plugins/__init__.py`](megaloader/plugins/__init__.py) to enable
 automatic URL detection.
 
 ### Technical details

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ automatically downloads content from several file hosting and media platforms.
 It works with a plugin-based architecture to provide a unified interface for
 downloading from multiple platforms.
 
+<!-- prettier-ignore -->
 > [!WARNING]
 > Many supported platforms host adult content. This tool is designed
 > for content creators and digital archivists who need to work with such
@@ -64,15 +65,16 @@ platforms are maintained on a best-effort basis.
 | ThotHub.TO  | thothub.to                                       | Videos, albums                                           | Extended |
 | Fapello     | fapello.com                                      | Profile extraction                                       | Extended |
 
+<!-- prettier-ignore -->
 > [!NOTE]
 > Extended plugins work as of 2025/08/25 but may occasionally break
 > without immediate fixes since I don't really use them.
 
 ## Installation
 
-Python 3.10 or newer is required, though we recommend Python 3.13 or higher for
-reproducibility. The installation process varies depending on your preferred
-dependency management approach.
+Python 3.10 or newer is required, though [I recommend](mise.toml) Python 3.13 or
+higher for reproducibility. The installation process varies depending on your
+preferred dependency management approach.
 
 Begin by cloning the repository to your local machine:
 
@@ -186,6 +188,7 @@ ground up. Development priorities focus on four core platforms (Bunkr,
 PixelDrain, Cyberdrop, and GoFile) while maintaining best-effort support for
 extended platforms.
 
+<!-- prettier-ignore -->
 > [!TIP]
 > Report issues through the
 > [GitHub Issues](https://github.com/totallynotdavid/megaloader/issues) tracker.
@@ -324,6 +327,7 @@ class NewPlatformPlugin(BasePlugin):
         return True
 ```
 
+<!-- prettier-ignore -->
 Register your plugin in the domain mapping located in
 [megaloader/plugins/__init__.py](megaloader/plugins/__init__.py) to enable
 automatic URL detection.

--- a/README.md
+++ b/README.md
@@ -51,19 +51,19 @@ We currently support 11 platforms with different maintenance priorities. Core
 platforms receive active development and feature updates, while extended
 platforms are maintained on a best-effort basis.
 
-| Platform    | Domain(s)                                        | Features                                                 | Priority |
-| ----------- | ------------------------------------------------ | -------------------------------------------------------- | -------- |
-| Bunkr       | bunkr.si, bunkr.la, bunkr.is, bunkr.ru, bunkr.su | Albums, single files, API extraction                     | Core     |
-| PixelDrain  | pixeldrain.com                                   | Files, lists, [proxy support](#pixeldrain-proxy-support) | Core     |
-| Cyberdrop   | cyberdrop.me, cyberdrop.to                       | Albums, galleries                                        | Core     |
-| GoFile      | gofile.io                                        | [Password-protected folders](#gofile-password-support)   | Core     |
-| Fanbox      | {creator}.fanbox.cc, fanbox.cc/@{creator}        | Creator content, [authentication](.env.example)          | Extended |
-| Pixiv       | pixiv.net                                        | Artwork, user galleries, [authentication](.env.example)  | Extended |
-| Rule34      | rule34.xxx                                       | Search results (tags), posts                             | Extended |
-| ThotsLife   | thotslife.com                                    | Albums, blog posts                                       | Extended |
-| ThotHub.VIP | thothub.vip                                      | Videos, albums                                           | Extended |
-| ThotHub.TO  | thothub.to                                       | Videos, albums                                           | Extended |
-| Fapello     | fapello.com                                      | Profile extraction                                       | Extended |
+| Platform    | Domain(s)                                        | Supports                                                                            | Priority |
+| ----------- | ------------------------------------------------ | ----------------------------------------------------------------------------------- | -------- |
+| Bunkr       | bunkr.si, bunkr.la, bunkr.is, bunkr.ru, bunkr.su | Albums, single files                                                                | Core     |
+| PixelDrain  | pixeldrain.com                                   | Lists, single files, also: [proxy support](#pixeldrain-proxy-support)               | Core     |
+| Cyberdrop   | cyberdrop.me, cyberdrop.to                       | Albums, single files                                                                | Core     |
+| GoFile      | gofile.io                                        | Folders, single files, also: [password-protected folders](#gofile-password-support) | Core     |
+| Fanbox      | {creator}.fanbox.cc, fanbox.cc/@{creator}        | Creator content, also: [authentication](.env.example)                               | Extended |
+| Pixiv       | pixiv.net                                        | Single artworks, user galleries, also: [authentication](.env.example)               | Extended |
+| Rule34      | rule34.xxx                                       | API support, search results (tags), posts, also: [authentication](.env.example)     | Extended |
+| ThotsLife   | thotslife.com                                    | Albums, blog posts                                                                  | Extended |
+| ThotHub.VIP | thothub.vip                                      | Videos, albums                                                                      | Extended |
+| ThotHub.TO  | thothub.to                                       | Videos, albums                                                                      | Extended |
+| Fapello     | fapello.com                                      | Model profiles                                                                      | Extended |
 
 <!-- prettier-ignore -->
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -283,76 +283,11 @@ for i, item in enumerate(items):
         print(f"Failed to download {item.filename}")
 ```
 
-## Contributing
+## Contributing 👋
 
-We welcome contributions ranging from bug fixes to new platform support. The
-development workflow emphasizes code quality through automated tooling and
-comprehensive type checking.
-
-The project includes several automated tasks that maintain code quality and
-consistency. These tools are configured in [pyproject.toml](pyproject.toml)
-([ruff](pyproject.toml?plain=1#L32) and [mypy](pyproject.toml?plain=1#L69)) and
-can be executed through mise:
-
-```bash
-mise run fix     # Format code and apply automated fixes via ruff
-mise run mypy    # Run comprehensive type checking
-mise run export  # Update requirements.txt from pyproject.toml
-```
-
-All contributions must pass the automated CI pipeline, which includes type
-safety verification, code style enforcement, and security scanning through
-CodeQL. Running `mise run mypy` and `mise run fix` locally ensures your changes
-will partially pass the automated checks.
-
-### Creating new plugins
-
-New platform plugins should follow established patterns for consistency and
-maintainability. The basic structure requires inheriting from `BasePlugin` and
-implementing the two core methods, with registration in the
-[domain registry](megaloader/plugins/__init__.py?plain=1#L16) for automatic URL
-detection.
-
-```python
-class NewPlatformPlugin(BasePlugin):
-    def __init__(self, url: str, **kwargs: Any) -> None:
-        super().__init__(url, **kwargs)
-        # Initialize HTTP session, configure headers, handle authentication
-
-    def export(self) -> Generator[Item, None, None]:
-        # Parse platform URLs and extract file information
-        # Handle pagination, albums, and individual files
-        # Yield Item objects with complete download metadata
-        pass
-
-    def download_file(self, item: Item, output_dir: str) -> bool:
-        # Execute actual file download and storage
-        # Handle platform-specific download logic
-        # Return success/failure status for error handling
-        return True
-```
-
-Register your plugin in the domain mapping located in
-[`megaloader/plugins/__init__.py`](megaloader/plugins/__init__.py) to enable
-automatic URL detection.
-
-### Technical details
-
-The runtime maintains a minimal dependency footprint with three core libraries:
-
-- `requests` handles HTTP operations and session management,
-- `beautifulsoup4` provides HTML parsing capabilities, and
-- `lxml` serves as the high-performance parser backend.
-
-Development dependencies include `ruff` for code formatting and
-linting, plus `mypy` for static type checking. The complete dependency tree is
-available in [requirements.txt](requirements.txt).
-
-Configuration management centralizes around [pyproject.toml](pyproject.toml),
-which contains settings for all tools including ruff, mypy, and packaging
-metadata. The [mise.toml](mise.toml) file provides development environment
-automation with exact tool versions and task orchestration for consistent
-development experiences.
+Contributions are welcome and appreciated! For a complete guide to getting
+started, including development setup, coding standards, and creating new
+plugins, see our [contributing guide](.github/CONTRIBUTING.md).
 
 ## Getting help
 
@@ -364,5 +299,6 @@ problematic URLs. Include DEBUG-level logging output to speed up debugging.
 For **feature requests**, submit through GitHub Issues with their respective use
 cases, supported platforms, example URLs, and workflow explanations.
 
-For **general questions**, use GitHub Discussions for questions about usage,
-architecture, or integration.
+For **general questions**, use
+[GitHub Discussions](https://github.com/totallynotdavid/megaloader/discussions)
+for questions about usage, architecture, or integration.

--- a/README.md
+++ b/README.md
@@ -3,18 +3,22 @@
 [![CodeQL](https://github.com/totallynotdavid/megaloader/actions/workflows/codeql.yml/badge.svg)](https://github.com/totallynotdavid/megaloader/actions/workflows/codeql.yml)
 [![lint and format check](https://github.com/totallynotdavid/megaloader/actions/workflows/checks.yml/badge.svg)](https://github.com/totallynotdavid/megaloader/actions/workflows/checks.yml)
 
-This project will make you smile. Megaloader is a package written in Python to
-automate downloads from various file hosting and media platforms.
+This project will make you smile. Megaloader is a package written in Python that
+automatically downloads content from several file hosting and media platforms.
+It works with a plugin-based architecture to provide a unified interface for
+downloading from multiple platforms.
 
 > [!WARNING]
 > Many supported platforms host adult content. This tool is designed
 > for content creators and digital archivists who need to work with such
 > platforms.
 
-## Quick start
+## Getting started
 
-The simplest way to use Megaloader is through its automatic URL detection
-system:
+The package has an utomatic URL detection system makes downloading content
+straightforward. The package analyzes URLs and selects the appropriate plugin
+automatically (see [plugins](megaloader/plugins/__init__.py)), requiring only
+the URL and destination path.
 
 ```python
 from megaloader import download
@@ -23,8 +27,8 @@ download("https://pixeldrain.com/u/95u1wnsd", "./downloads")
 download("https://cyberdrop.me/a/0OpiyaOV", "./downloads")
 ```
 
-You only need to pass the URL and the path to the folder where you want to store
-the downloaded files. For more control, you can work with plugins directly:
+When you need more control over the download process, you can specify the plugin
+class directly. This is useful if a platform domain changes.
 
 ```python
 from megaloader import Bunkr, download
@@ -36,12 +40,15 @@ download(
 )
 ```
 
-In both cases, the files will be stored in the specified download directory.
+The downloaded files are organized in the specified directory, with plugins
+automatically creating subdirectories based on album names or content structure
+when appropriate.
 
 ## Supported platforms
 
-Currently, Megaloader supports 11 different platforms with varying levels of
-maintenance priority:
+We currently support 11 platforms with different maintenance priorities. Core
+platforms receive active development and feature updates, while extended
+platforms are maintained on a best-effort basis.
 
 | Platform    | Domain(s)                                        | Features                             | Priority |
 | ----------- | ------------------------------------------------ | ------------------------------------ | -------- |
@@ -58,52 +65,57 @@ maintenance priority:
 | Fapello     | fapello.com                                      | Profile extraction                   | Extended |
 
 > [!NOTE]
-> **Core** plugins receive active maintenance and feature development.
->
-> **Extended** plugins are supported on a best-effort basis and may occasionally
-> break without immediate fixes as I don't personally use them. They all work as
-> of 2025/08/25
+> Extended plugins work as of 2025/08/25 but may occasionally break
+> without immediate fixes since I don't really use them.
 
 ## Installation
 
-You need a modern Python version, I tried to give support to at least Python
-3.10, but I recommend using Python 3.13 or higher (see [mise.toml](mise.toml)),
-however, older versions may work without issues.
+Python 3.10 or newer is required, though we recommend Python 3.13 or higher for
+reproducibility. The installation process varies depending on your preferred
+dependency management approach.
 
-We'll walk through several installation methods to match your development
-workflow.
-
-First, clone the repository to your local machine:
+Begin by cloning the repository to your local machine:
 
 ```bash
 git clone https://github.com/totallynotdavid/megaloader
 cd megaloader
 ```
 
-Pick your poison:
-
 <details>
-<summary><b>For most users (standard pip)</b></summary>
+<summary>
 
-If you're familiar with traditional Python package management, install
-dependencies from our requirements file:
+#### Standard pip installation
+
+</summary>
+
+For users familiar with traditional Python package management, install
+dependencies directly from the requirements file. This method works across all
+Python environments and doesn't require additional tooling.
+
+On macOS/Linux:
 
 ```bash
-# On macOS/Linux
 python3 -m pip install -r requirements.txt
+```
 
-# On Windows
+On Windows:
+
+```bash
 python -m pip install -r requirements.txt
 ```
 
 </details>
 
-Or if you're a developer:
-
 <details>
-<summary><b>For Poetry users</b></summary>
+<summary>
 
-You can install Poetry by following their [guide](https://python-poetry.org/docs/#installing-with-the-official-installer). If your workflow already includes Poetry for dependency management:
+#### Poetry installation
+
+</summary>
+
+After installing Poetry following their
+[official guide](https://python-poetry.org/docs/#installing-with-the-official-installer),
+install the project dependencies:
 
 ```bash
 poetry install
@@ -112,73 +124,98 @@ poetry install
 </details>
 
 <details>
-<summary><b>For uv users</b></summary>
+<summary>
 
-UV provides faster dependency resolution and installation. After
-[installing UV](https://docs.astral.sh/uv/getting-started/installation/):
+### UV installation
+
+</summary>
+
+uv offers faster dependency resolution and installation than pip. After
+[installing uv](https://docs.astral.sh/uv/getting-started/installation/), set up
+the project:
 
 ```bash
 uv install
 ```
+
 </details>
 
 <details>
-<summary><b>Recommended: for mise users</b></summary>
+<summary>
 
-We recommend mise for a more reliable setup experience across different
-operating systems. After
+#### Recommended: mise installation
+
+</summary>
+
+I recommend mise for the most reliable setup experience across different
+operating systems. Mise automatically manages Python versions, tool
+installations, and project tasks. After
 [installing mise](https://mise.jdx.dev/getting-started.html):
 
 ```bash
-mise install  # Sets up Python 3.13.7, uv, and ruff automatically
-mise run install # Installs the dependencies of the project
+mise install      # Sets up Python 3.13.7, uv, and ruff automatically
+mise run install  # Installs project dependencies
 ```
 
 </details>
 
-Once you have everything installed, you can play around with the
-[example](example.py) script:
+### Testing the installation
+
+Once installation is complete, verify everything works by running the example
+script. This script demonstrates basic functionality and helps confirm your
+setup:
+
+If you're using mise/uv:
 
 ```bash
-# If using mise/uv
 uv run example.py
+```
 
-# If using standard Python
+If you're using standard Python:
+
+```bash
 python example.py
 ```
 
+The example script located at [example.py](example.py) contains usage examples
+that showcase the package's core features.
+
 ## Project background
 
-This project was originally developed by [@Ximaz](https://github.com/Ximaz), the
-original repository was deleted or made private at some point during/after 2023.
-I decided to continue development and have currently finished
-completely refactoring the codebase to fix changes made by the sites we support.
+This project was originally created by [@Ximaz](https://github.com/Ximaz), but
+the original repository was deleted or made private sometime during or
+after 2023. I've taken over development and completely refactored the codebase
+to fix issues caused by changes made by the supported sites.
 
 The
 [original implementation](https://github.com/totallynotdavid/megaloader/tree/9adeffe2d4055d26f9db2b7fcbf6f92de0aca628)
-has been largely rewritten with my own opinionated ideas. My focus is on the
-following plugins (Bunkr, PixelDrain, Cyberdrop, and GoFile, which I decided to
-call core) while providing best-effort support for the extended set.
+served as inspiration, but the current codebase has been mostly rebuilt from the
+ground up. Development priorities focus on four core platforms (Bunkr,
+PixelDrain, Cyberdrop, and GoFile) while maintaining best-effort support for
+extended platforms.
 
 > [!TIP]
-> If you encounter issues with any plugin, please report them through the
+> Report issues through the
 > [GitHub Issues](https://github.com/totallynotdavid/megaloader/issues) tracker.
-> Include specific URLs, error messages (logs with DEBUG), and your Python
-> version for faster troubleshooting.
+> Include specific URLs, complete error messages with DEBUG logging enabled, and
+> your Python version.
 
-## Understanding the architecture
+## Architecture overview
 
-The package has a plugin-based architecture. Each supported platform is
-implemented as a separate plugin that inherits from a `BasePlugin` abstract base
-class.
+The project uses a plugin-based architecture where each supported platform is
+implemented as a separate plugin inheriting from the `BasePlugin` abstract base
+class defined in [megaloader/plugin.py](megaloader/plugin.py).
 
-Every plugin implements two methods:
+Each plugin implements two core methods that handle the complete download
+workflow:
 
-- `export()` - Parses platform-specific pages and extracts file information
-- `download_file()` - Handles the actual file retrieval and storage
+- The `export()` method parses platform-specific pages and extracts file
+  information, yielding `Item` objects containing download metadata.
+- The `download_file()` method handles actual file retrieval and storage,
+  returning success or failure status.
 
-An `Item` dataclass is used to pass information between these operations. See
-[megaloader/plugin.py](megaloader/plugin.py?plain=1#L7):
+The `Item` dataclass serves as the communication bridge between extraction and
+download operations:
 
 ```python
 @dataclass
@@ -190,15 +227,19 @@ class Item:
     metadata: Optional[dict[str, Any]] = None  # Additional platform data
 ```
 
-### Advanced usage
+## Advanced usage
 
-Some plugins support additional configuration options.
+Several plugins support additional configuration options that enable specialized
+functionality. These options are passed as keyword arguments to the `download()`
+function or plugin constructor.
 
-For example, PixelDrain has an additional `use_proxy` option which lets you use
-a list of proxies provided by [@sh13y](https://github.com/sh13y) via
-[Cloudflare workers](https://github.com/sh13y/pixeldrain-ratelimit-bypasser). Of
-course, this can help with rate limiting issues but the caveat is that you have
-to trust his code/deployments[^1]. This option is turned off by default.
+### PixelDrain proxy support
+
+PixelDrain includes an optional proxy system that can help bypass rate limiting.
+This feature uses proxies provided by [@sh13y](https://github.com/sh13y) via
+[Cloudflare workers](https://github.sh13y/pixeldrain-ratelimit-bypasser). The
+proxy option is disabled by default since it requires trusting external
+infrastructure. You can use it like this:
 
 ```python
 download(
@@ -208,8 +249,10 @@ download(
 )
 ```
 
-GoFile allows users to put a password to access their files/albums. The module
-support this via the password prop.
+### GoFile password support
+
+GoFile allows uploaders to password-protect their albums and folders. The plugin
+supports this authentication mechanism through the password parameter.
 
 ```python
 download(
@@ -219,19 +262,17 @@ download(
 )
 ```
 
-For maximum control over the download process, you can import a specific plugin
-and use it. If you intend to provide a service using this package, you should
-handle rate limiting, caching, URL validation by yourself. This package is not
-designed for high stressed scenarios (for now).
+### Direct plugin usage
 
-To use the plugin class, you can do something like this:
+For applications requiring fine-grained control over the download process, you
+can import and use plugin classes directly.
 
 ```python
 from megaloader.plugins import Cyberdrop
 
 plugin = Cyberdrop("https://cyberdrop.me/a/album_id")
 
-# Extract all items first (useful for progress tracking)
+# Extract all items first for progress tracking
 items = list(plugin.export())
 print(f"Found {len(items)} files to download")
 
@@ -243,85 +284,83 @@ for i, item in enumerate(items):
         print(f"Failed to download {item.filename}")
 ```
 
-## How to contribute
+## Contributing
 
-We welcome contributions whether you're fixing bugs, improving existing plugins,
-or adding support for new platforms.
+We welcome contributions ranging from bug fixes to new platform support. The
+development workflow emphasizes code quality through automated tooling and
+comprehensive type checking.
 
-Our development workflow includes several automated tasks for code quality:
+The project includes several automated tasks that maintain code quality and
+consistency. These tools are configured in [pyproject.toml](pyproject.toml)
+([ruff](pyproject.toml?plain=1#L32) and [mypy](pyproject.toml?plain=1#L69)) and
+can be executed through mise:
 
 ```bash
-mise run fix     # Format code and apply safe automated fixes via ruff
+mise run fix     # Format code and apply automated fixes via ruff
 mise run mypy    # Run comprehensive type checking
 mise run export  # Update requirements.txt from pyproject.toml
 ```
 
-All contributions must meet our automated CI pipeline requirements which include
-[type safety](.github/workflows/checks.yml) (you'll be fine if you pass
-`mise run mypy`), [code style](.github/workflows/checks.yml) (`mise run fix`)
-and [security](.github/workflows/codeql.yml) (codeql).
+All contributions must pass the automated CI pipeline, which includes type
+safety verification, code style enforcement, and security scanning through
+CodeQL. Running `mise run mypy` and `mise run fix` locally ensures your changes
+will partially pass the automated checks.
 
 ### Creating new plugins
 
-When developing plugins for new platforms, follow these guidelines:
-
-1. **Inherit from BasePlugin** and implement both required methods
-2. **Register your plugin** in the domain registry for automatic detection. See
-   [plugins/**init**.py](megaloader/plugins/__init__.py)
-3. (Optional) **Try to follow existing patterns** for consistency with the
-   existing codebase
-
-Here's a minimal plugin template:
+New platform plugins should follow established patterns for consistency and
+maintainability. The basic structure requires inheriting from `BasePlugin` and
+implementing the two core methods, with registration in the domain registry for
+automatic URL detection.
 
 ```python
 class NewPlatformPlugin(BasePlugin):
     def __init__(self, url: str, **kwargs: Any) -> None:
         super().__init__(url, **kwargs)
-        # Initialize session, configure headers, etc.
+        # Initialize HTTP session, configure headers, handle authentication
 
     def export(self) -> Generator[Item, None, None]:
-        # Parse the URL and extract file information
-        # Yield Item objects with download metadata
+        # Parse platform URLs and extract file information
+        # Handle pagination, albums, and individual files
+        # Yield Item objects with complete download metadata
         pass
 
     def download_file(self, item: Item, output_dir: str) -> bool:
-        # Handle actual file download and storage
-        # Return success/failure status
+        # Execute actual file download and storage
+        # Handle platform-specific download logic
+        # Return success/failure status for error handling
         return True
 ```
 
+Register your plugin in the domain mapping located in
+[megaloader/plugins/**init**.py](megaloader/plugins/__init__.py) to enable
+automatic URL detection.
+
 ### Technical details
 
-**Dependencies**: The runtime has a minimal footprint with just three core
-dependencies - `requests` for HTTP operations, `beautifulsoup4` for HTML
-parsing, and `lxml` as the high-performance parser backend for `beautifulsoup4`.
-Development dependencies include `ruff` for code quality and `mypy` for type
-safety. The [requirements.txt](requirements.txt) has a more extensive list but
-includes dependencies of our dependencies.
+The runtime maintains a minimal dependency footprint with three core libraries.
+`requests` handles HTTP operations and session management, `beautifulsoup4`
+provides HTML parsing capabilities, and `lxml` serves as the high-performance
+parser backend. Development dependencies include `ruff` for code formatting and
+linting, plus `mypy` for static type checking. The complete dependency tree is
+available in [requirements.txt](requirements.txt).
 
-**Configuration**: The `pyproject.toml` serves as the central configuration
-file, while `mise.toml` provides development environment automation with exact
-tool versions and task orchestration. Both ruff and mypy are configured in
-pyproject.toml.
+Configuration management centralizes around [pyproject.toml](pyproject.toml),
+which contains settings for all tools including ruff, mypy, and packaging
+metadata. The [mise.toml](mise.toml) file provides development environment
+automation with exact tool versions and task orchestration for consistent
+development experiences.
 
 ## Getting help
 
-**Bug Reports**: Use our
-[GitHub Issues](https://github.com/totallynotdavid/megaloader/issues) tracker.
-Include Python version, complete error messages, and specific URLs that are
-failing.
+For **bug reports** use
+[GitHub Issues](https://github.com/totallynotdavid/megaloader/issues). Make sure
+to include your Python version, complete error messages, stack traces, and
+problematic URLs. Include DEBUG-level logging output to speed up debugging.
 
-**Feature Requests**: Also through GitHub Issues. Describe your use case and the
-platform you'd like to see supported.
+For **feature requests**, submit through GitHub Issues with their respective use
+cases, supported platforms, example URLs, and workflow explanations.
 
-**General Questions**: GitHub Discussions are appropriate for general questions
-about usage or architecture.
-
-Remember to include relevant technical details like your Python version,
-dependency versions (you can get this with `uv tree` if using UV), and complete
-stack traces when reporting issues. This information significantly speeds up the
-debugging process and helps us provide better support.
-
-[^1]:
-    The repo may not be the code deployed on the actual worker and could
-    introduce you to man in the middle attacks.
+For **general questions**, use GitHub Discussions for questions about usage,
+architecture, or integration. This helps build a knowledge base for the
+community.

--- a/README.md
+++ b/README.md
@@ -83,9 +83,7 @@ cd megaloader
 
 <details>
 <summary>
-
 #### Standard pip installation
-
 </summary>
 
 For users familiar with traditional Python package management, install
@@ -108,9 +106,7 @@ python -m pip install -r requirements.txt
 
 <details>
 <summary>
-
 #### Poetry installation
-
 </summary>
 
 After installing Poetry following their
@@ -125,9 +121,7 @@ poetry install
 
 <details>
 <summary>
-
-### UV installation
-
+#### UV installation
 </summary>
 
 uv offers faster dependency resolution and installation than pip. After

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ uv install
 I recommend mise for the most reliable setup experience across different
 operating systems. Mise automatically manages Python versions, tool
 installations, and project tasks. After
-[installing mise](https://mise.jdx.dev/getting-started.html):
+[installing mise](https://mise.jdx.dev/getting-started.html), run:
 
 ```bash
 mise install      # Sets up Python 3.13.7, uv, and ruff automatically

--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ Each plugin implements two core methods that handle the complete download
 workflow:
 
 - The `export()` method parses platform-specific pages and extracts file
-  information, yielding `Item` objects containing download metadata.
+  information, yielding [`Item`](megaloader/plugin.py?plain=1#L7) objects
+  containing download metadata.
 - The `download_file()` method handles actual file retrieval and storage,
   returning success or failure status.
 

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ class NewPlatformPlugin(BasePlugin):
 ```
 
 Register your plugin in the domain mapping located in
-[megaloader/plugins/**init**.py](megaloader/plugins/__init__.py) to enable
+[megaloader/plugins/__init__.py](megaloader/plugins/__init__.py) to enable
 automatic URL detection.
 
 ### Technical details

--- a/README.md
+++ b/README.md
@@ -151,12 +151,12 @@ python example.py
 
 This project was originally developed by [@Ximaz](https://github.com/Ximaz), the
 original repository was deleted or made private at some point during/after 2023.
-I decided to continue development on my work, and have currently finished
+I decided to continue development and have currently finished
 completely refactoring the codebase to fix changes made by the sites we support.
 
 The
 [original implementation](https://github.com/totallynotdavid/megaloader/tree/9adeffe2d4055d26f9db2b7fcbf6f92de0aca628)
-has been largely rewritten with my own opinionade ideas. My focus is on the
+has been largely rewritten with my own opinionated ideas. My focus is on the
 following plugins (Bunkr, PixelDrain, Cyberdrop, and GoFile, which I decided to
 call core) while providing best-effort support for the extended set.
 

--- a/README.md
+++ b/README.md
@@ -51,19 +51,19 @@ We currently support 11 platforms with different maintenance priorities. Core
 platforms receive active development and feature updates, while extended
 platforms are maintained on a best-effort basis.
 
-| Platform    | Domain(s)                                        | Supports                                                                            | Priority |
-| ----------- | ------------------------------------------------ | ----------------------------------------------------------------------------------- | -------- |
-| Bunkr       | bunkr.si, bunkr.la, bunkr.is, bunkr.ru, bunkr.su | Albums, single files                                                                | Core     |
-| PixelDrain  | pixeldrain.com                                   | Lists, single files, also: [proxy support](#pixeldrain-proxy-support)               | Core     |
-| Cyberdrop   | cyberdrop.me, cyberdrop.to                       | Albums, single files                                                                | Core     |
-| GoFile      | gofile.io                                        | Folders, single files, also: [password-protected folders](#gofile-password-support) | Core     |
-| Fanbox      | {creator}.fanbox.cc, fanbox.cc/@{creator}        | Creator content, also: [authentication](.env.example)                               | Extended |
-| Pixiv       | pixiv.net                                        | Single artworks, user galleries, also: [authentication](.env.example)               | Extended |
-| Rule34      | rule34.xxx                                       | API support, search results (tags), posts, also: [authentication](.env.example)     | Extended |
-| ThotsLife   | thotslife.com                                    | Albums, blog posts                                                                  | Extended |
-| ThotHub.VIP | thothub.vip                                      | Videos, albums                                                                      | Extended |
-| ThotHub.TO  | thothub.to                                       | Videos, albums                                                                      | Extended |
-| Fapello     | fapello.com                                      | Model profiles                                                                      | Extended |
+| Platform    | Domain(s)                                        | Supports                                                                      | Priority |
+| ----------- | ------------------------------------------------ | ----------------------------------------------------------------------------- | -------- |
+| Bunkr       | bunkr.si, bunkr.la, bunkr.is, bunkr.ru, bunkr.su | Albums, single files                                                          | Core     |
+| PixelDrain  | pixeldrain.com                                   | Lists, single files, [proxy support](#pixeldrain-proxy-support)               | Core     |
+| Cyberdrop   | cyberdrop.me, cyberdrop.to                       | Albums, single files                                                          | Core     |
+| GoFile      | gofile.io                                        | Folders, single files, [password-protected folders](#gofile-password-support) | Core     |
+| Fanbox      | {creator}.fanbox.cc, fanbox.cc/@{creator}        | Creator content, [authentication](.env.example)                               | Extended |
+| Pixiv       | pixiv.net                                        | Single artworks, user galleries, [authentication](.env.example)               | Extended |
+| Rule34      | rule34.xxx                                       | Tags, posts, [API support](.env.example)                                      | Extended |
+| ThotsLife   | thotslife.com                                    | Albums, blog posts                                                            | Extended |
+| ThotHub.VIP | thothub.vip                                      | Videos, albums                                                                | Extended |
+| ThotHub.TO  | thothub.to                                       | Videos, albums                                                                | Extended |
+| Fapello     | fapello.com                                      | Model profiles                                                                | Extended |
 
 <!-- prettier-ignore -->
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ platforms are maintained on a best-effort basis.
 
 ## Installation
 
-Python 3.10 or newer is required, though [I recommend](mise.toml) Python 3.13 or
+Python 3.10 or newer is required, though [I recommend](mise.toml?plain=1#L5) Python 3.13 or
 higher for reproducibility. The installation process varies depending on your
 preferred dependency management approach.
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ git clone https://github.com/totallynotdavid/megaloader
 cd megaloader
 ```
 
+Then, pick your poison (you only need to follow one):
+
 <details>
 <summary>
 Standard pip installation

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ downloading from multiple platforms.
 
 ## Getting started
 
-The package has an utomatic URL detection system makes downloading content
+The package has an automatic URL detection system that makes downloading content
 straightforward. The package analyzes URLs and selects the appropriate plugin
 automatically (see [plugins](megaloader/plugins/__init__.py)), requiring only
 the URL and destination path.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-# Megaloader
+# [pkg]: megaloader
 
-### Introduction
+[![CodeQL](https://github.com/totallynotdavid/megaloader/actions/workflows/codeql.yml/badge.svg)](https://github.com/totallynotdavid/megaloader/actions/workflows/codeql.yml)
+[![lint and format check](https://github.com/totallynotdavid/megaloader/actions/workflows/checks.yml/badge.svg)](https://github.com/totallynotdavid/megaloader/actions/workflows/checks.yml)
 
 This project will make you smile. It allows you to use some download plugins for many websites such as:
 
 - [Bunkr](https://bunkrr.su/) (and its other domains),
 - [PixelDrain](https://pixeldrain.com/),
 - [Cyberdrop](http://www.cyberdrop.me/),
-- [Fanbox](https://www.fanbox.cc),
 - [GoFile](http://www.gofile.io/),
+- [Fanbox](https://www.fanbox.cc),
 - [Pixiv](http://www.pixiv.net/),
 - [Rule34](http://www.rule34.xxx/),
 - [ThotsLife](http://www.thotslife.com/),
@@ -18,33 +19,66 @@ This project will make you smile. It allows you to use some download plugins for
 
 The list may grow, but at the moment, it's all about NSFW. Cyberdrop, GoFile, Thotslife and ThotHub are knowned to host some leaks about nudity, while Rule34, Pixiv and Fanbox are hosting some hentai arts.
 
+This project was originally created by [@Ximaz](https://github.com/Ximaz). At some point after 2023, he deleted this repo and because I made a contribution before I still have my fork available. I've decided to update and partially mantain the hosts he initially wrote the modules for. At this stage, the repo doesn't have a lot of the original code wrote by then (check out the last commit made by him on this repo on https://github.com/totallynotdavid/megaloader/tree/9adeffe2d4055d26f9db2b7fcbf6f92de0aca628) and most of the implementations were redone by me as many if not all the modules were not working as of 2025.
+
+I'll mostly focus on the first 4 plugins (bunkr, pixeldrain, cyberdrop, gofile) and mantain them as long as I can, while I'll try to mantain the rest of the hosts, as I don't really use them, they may break without me noticing it. So, feel free to create an issue at https://github.com/totallynotdavid/megaloader/issues if something breaks and I'll try my best.
+
 ### Setup
 
-In order to make the project working without error, you need to install the modules in `requirements.txt`. You can achieve this using the following command :
+Start by cloning the project:
+
+```bash
+git clone https://github.com/totallynotdavid/megaloader.git
+cd megaloader
+```
+
+For those who use bare Python, you just need to install the modules in `requirements.txt` (mirror of pyproject.toml and uv.lock). You can achieve this using the following command:
 
 ```bash
 python3 -m pip install -r requirements.txt
 ```
 
+On Windows machines, you may need to use `python` instead:
+
+```bash
+python -m pip install -r requirements.txt
+```
+
+If you're a Poetry user, you can install the dependencies using:
+
+```bash
+poetry install
+```
+
+Similarly, if you use uv, you can install the dependencies using:
+
+```bash
+uv install
+```
+
+I personally use [mise](https://mise.jdx.dev/getting-started.html) (works on Windows, Linux and macOS) and highly recommend it. If you decide to try mise and after following their installation steps, you can just run:
+
+```bash
+mise install
+```
+
+This will install uv and python as set in mise.toml and also give you access to tasks (something similar can be done in poetry via poe the poet but I prefer this abstraction). To run then the example script, you can run:
+
+```bash
+uv run example.py
+```
+
+Otherwise, you can run the script using the Python interpreter directly:
+
+```bash
+python example.py
+```
+
 ### Goal
 
-The goal of this project is to create script to download all content from a specific website and make it as a plugin using the Megaloader HTTP request, made using `requests` modules only.
-
-### Why ?
-
-I'm interested in the download automation. Sometimes it's easy to make, sometimes it's not. But everytime I do a downloader that works, I put it on GitHub using a new repository. This time, I'm going to make a Monolith repository containing all my downloader adapted for a plugin form.
+The goal of this project is to create script to download all content from a specific website and make it available as a plugin using the `requests` and `beautifulsoup4` modules only. `lxml` is also included as a dependency of `beautifulsoup4`. This list differs from requirements.txt as that file is just a mirror of pyproject.toml and uv includes more dependencies. But the overall direct dependencies are these.
 
 ### Contribution
 
 If you want to contribute, you can either make a pull request to patch an error in a Megaloader's plugin, or create yours which I just have to validate before merging.
 If you're facing any error, please, open an issue.
-
-### Thanks
-
-Thanks for the support you're giving to me, it makes me happy to see a new star notification.
-
-# Snippets
-
-Below, you will be able to see many snippets on existing plugins to see how it can be used. Sure, you're gonna need to see in depth the source code of each plugin because some don't work the same as other, since some websites asks for certain auth token, or else, and other don't.
-
-Many snippets example are foundable at `examples/`. You can open them, copy their code and paste it into the `test.py` file at the root of the project. Then, you can launch the script.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ uv install
 </details>
 
 <details>
-<summary>
+<summary open>
 Recommended: mise installation
 </summary>
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ cd megaloader
 Pick your poison:
 
 <details>
-<summary>**For most users (standard pip)**</summary>
+<summary><b>For most users (standard pip)</b></summary>
 
 If you're familiar with traditional Python package management, install
 dependencies from our requirements file:
@@ -101,9 +101,9 @@ python -m pip install -r requirements.txt
 Or if you're a developer:
 
 <details>
-<summary>**For [Poetry](https://python-poetry.org/docs/#installing-with-the-official-installer) users**</summary>
+<summary><b>For Poetry users</b></summary>
 
-If your workflow already includes Poetry for dependency management:
+You can install Poetry by following their [guide](https://python-poetry.org/docs/#installing-with-the-official-installer). If your workflow already includes Poetry for dependency management:
 
 ```bash
 poetry install
@@ -112,7 +112,7 @@ poetry install
 </details>
 
 <details>
-<summary>**For uv users**</summary>
+<summary><b>For uv users</b></summary>
 
 UV provides faster dependency resolution and installation. After
 [installing UV](https://docs.astral.sh/uv/getting-started/installation/):
@@ -123,7 +123,7 @@ uv install
 </details>
 
 <details>
-<summary>**Recommended: for mise users**</summary>
+<summary><b>Recommended: for mise users</b></summary>
 
 We recommend mise for a more reliable setup experience across different
 operating systems. After

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ UV provides faster dependency resolution and installation. After
 ```bash
 uv install
 ```
+</details>
 
 <details>
 <summary>**Recommended: for mise users**</summary>

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ uv install
 
 <details>
 <summary open>
-Recommended: mise installation
+<b>Recommended</b>: mise installation
 </summary>
 
 I recommend mise for the most reliable setup experience across different

--- a/README.md
+++ b/README.md
@@ -338,12 +338,19 @@ automatic URL detection.
 
 ### Technical details
 
-The runtime maintains a minimal dependency footprint with three core libraries.
-`requests` handles HTTP operations and session management, `beautifulsoup4`
-provides HTML parsing capabilities, and `lxml` serves as the high-performance
-parser backend. Development dependencies include `ruff` for code formatting and
-linting, plus `mypy` for static type checking. The complete dependency tree is
-available in [requirements.txt](requirements.txt).
+The runtime maintains a minimal dependency footprint with three core libraries:
+
+- `requests` handles HTTP operations and session management,
+- `beautifulsoup4` provides HTML parsing capabilities, and
+- `lxml` serves as the high-performance parser backend.
+
+Development dependencies include:
+
+- `ruff` for code formatting and linting, plus
+- `mypy` for static type checking.
+
+The complete dependency tree is available in
+[requirements.txt](requirements.txt).
 
 Configuration management centralizes around [pyproject.toml](pyproject.toml),
 which contains settings for all tools including ruff, mypy, and packaging

--- a/README.md
+++ b/README.md
@@ -3,82 +3,320 @@
 [![CodeQL](https://github.com/totallynotdavid/megaloader/actions/workflows/codeql.yml/badge.svg)](https://github.com/totallynotdavid/megaloader/actions/workflows/codeql.yml)
 [![lint and format check](https://github.com/totallynotdavid/megaloader/actions/workflows/checks.yml/badge.svg)](https://github.com/totallynotdavid/megaloader/actions/workflows/checks.yml)
 
-This project will make you smile. It allows you to use some download plugins for many websites such as:
+This project will make you smile. Megaloader is a package written in Python to
+automate downloads from various file hosting and media platforms.
 
-- [Bunkr](https://bunkrr.su/) (and its other domains),
-- [PixelDrain](https://pixeldrain.com/),
-- [Cyberdrop](http://www.cyberdrop.me/),
-- [GoFile](http://www.gofile.io/),
-- [Fanbox](https://www.fanbox.cc),
-- [Pixiv](http://www.pixiv.net/),
-- [Rule34](http://www.rule34.xxx/),
-- [ThotsLife](http://www.thotslife.com/),
-- [ThotHub.VIP](http://www.thothub.vip/),
-- [ThotHub.TO](http://www.thothub.to/),
-- [Fapello](http://www.fapello.com/).
+> [!WARNING] Many supported platforms host adult content. This tool is designed
+> for content creators and digital archivists who need to work with such
+> platforms.
 
-The list may grow, but at the moment, it's all about NSFW. Cyberdrop, GoFile, Thotslife and ThotHub are knowned to host some leaks about nudity, while Rule34, Pixiv and Fanbox are hosting some hentai arts.
+## Quick start
 
-This project was originally created by [@Ximaz](https://github.com/Ximaz). At some point after 2023, he deleted this repo and because I made a contribution before I still have my fork available. I've decided to update and partially mantain the hosts he initially wrote the modules for. At this stage, the repo doesn't have a lot of the original code wrote by then (check out the last commit made by him on this repo on https://github.com/totallynotdavid/megaloader/tree/9adeffe2d4055d26f9db2b7fcbf6f92de0aca628) and most of the implementations were redone by me as many if not all the modules were not working as of 2025.
+The simplest way to use Megaloader is through its automatic URL detection
+system:
 
-I'll mostly focus on the first 4 plugins (bunkr, pixeldrain, cyberdrop, gofile) and mantain them as long as I can, while I'll try to mantain the rest of the hosts, as I don't really use them, they may break without me noticing it. So, feel free to create an issue at https://github.com/totallynotdavid/megaloader/issues if something breaks and I'll try my best.
+```python
+from megaloader import download
 
-### Setup
+download("https://pixeldrain.com/u/95u1wnsd", "./downloads")
+download("https://cyberdrop.me/a/0OpiyaOV", "./downloads")
+```
 
-Start by cloning the project:
+You only need to pass the URL and the path to the folder where you want to store
+the downloaded files. For more control, you can work with plugins directly:
+
+```python
+from megaloader import Bunkr, download
+
+download(
+    "https://bunkrr.su/d/megaloader-main-RKEICuly.zip",
+    "./downloads",
+    plugin_class=Bunkr,
+)
+```
+
+In both cases, the files will be stored in the specified download directory.
+
+## Supported platforms
+
+Currently, Megaloader supports 11 different platforms with varying levels of
+maintenance priority:
+
+| Platform    | Domain(s)                                        | Features                             | Priority |
+| ----------- | ------------------------------------------------ | ------------------------------------ | -------- |
+| Bunkr       | bunkr.si, bunkr.la, bunkr.is, bunkr.ru, bunkr.su | Albums, single files, API extraction | Core     |
+| PixelDrain  | pixeldrain.com                                   | Files, lists, proxy support          | Core     |
+| Cyberdrop   | cyberdrop.me, cyberdrop.to                       | Albums, galleries                    | Core     |
+| GoFile      | gofile.io                                        | Password-protected folders           | Core     |
+| Fanbox      | {creator}.fanbox.cc, fanbox.cc/@{creator}        | Creator content, authentication      | Extended |
+| Pixiv       | pixiv.net                                        | Artwork, user galleries              | Extended |
+| Rule34      | rule34.xxx                                       | Search results, posts                | Extended |
+| ThotsLife   | thotslife.com                                    | Albums, profiles                     | Extended |
+| ThotHub.VIP | thothub.vip                                      | Platform content                     | Extended |
+| ThotHub.TO  | thothub.to                                       | Platform content                     | Extended |
+| Fapello     | fapello.com                                      | Profile extraction                   | Extended |
+
+> [!NOTE] **Core** plugins receive active maintenance and feature development.
+> **Extended** plugins are supported on a best-effort basis and may occasionally
+> break without immediate fixes as I don't personally use them. They all work as
+> of 2025/08/25
+
+## Installation
+
+You need a modern Python version, I tried to give support to at least Python
+3.10, but I recommend using Python 3.13 or higher (see [mise.toml](mise.toml)),
+however, older versions may work without issues.
+
+We'll walk through several installation methods to match your development
+workflow.
+
+First, clone the repository to your local machine:
 
 ```bash
-git clone https://github.com/totallynotdavid/megaloader.git
+git clone https://github.com/totallynotdavid/megaloader
 cd megaloader
 ```
 
-For those who use bare Python, you just need to install the modules in `requirements.txt` (mirror of pyproject.toml and uv.lock). You can achieve this using the following command:
+Pick your poison:
+
+<details>
+<summary>**For most users (standard pip)**</summary>
+
+If you're familiar with traditional Python package management, install
+dependencies from our requirements file:
 
 ```bash
+# On macOS/Linux
 python3 -m pip install -r requirements.txt
-```
 
-On Windows machines, you may need to use `python` instead:
-
-```bash
+# On Windows
 python -m pip install -r requirements.txt
 ```
 
-If you're a Poetry user, you can install the dependencies using:
+</details>
+
+Or if you're a developer:
+
+<details>
+<summary>**For [Poetry](https://python-poetry.org/docs/#installing-with-the-official-installer) users**</summary>
+
+If your workflow already includes Poetry for dependency management:
 
 ```bash
 poetry install
 ```
 
-Similarly, if you use uv, you can install the dependencies using:
+</details>
+
+<details>
+<summary>**For uv users**</summary>
+
+UV provides faster dependency resolution and installation. After
+[installing UV](https://docs.astral.sh/uv/getting-started/installation/):
 
 ```bash
 uv install
 ```
 
-I personally use [mise](https://mise.jdx.dev/getting-started.html) (works on Windows, Linux and macOS) and highly recommend it. If you decide to try mise and after following their installation steps, you can just run:
+<details>
+<summary>**Recommended: for mise users**</summary>
+
+We recommend mise for a more reliable setup experience across different
+operating systems. After
+[installing mise](https://mise.jdx.dev/getting-started.html):
 
 ```bash
-mise install
+mise install  # Sets up Python 3.13.7, uv, and ruff automatically
+mise run install # Installs the dependencies of the project
 ```
 
-This will install uv and python as set in mise.toml and also give you access to tasks (something similar can be done in poetry via poe the poet but I prefer this abstraction). To run then the example script, you can run:
+</details>
+
+Once you have everything installed, you can play around with the
+[example](example.py) script:
 
 ```bash
+# If using mise/uv
 uv run example.py
-```
 
-Otherwise, you can run the script using the Python interpreter directly:
-
-```bash
+# If using standard Python
 python example.py
 ```
 
-### Goal
+## Project background
 
-The goal of this project is to create script to download all content from a specific website and make it available as a plugin using the `requests` and `beautifulsoup4` modules only. `lxml` is also included as a dependency of `beautifulsoup4`. This list differs from requirements.txt as that file is just a mirror of pyproject.toml and uv includes more dependencies. But the overall direct dependencies are these.
+This project was originally developed by [@Ximaz](https://github.com/Ximaz), the
+original repository was deleted or made private at some point during/after 2023.
+I decided to continue development on my work, and have currently finished
+completely refactoring the codebase to fix changes made by the sites we support.
 
-### Contribution
+The
+[original implementation](https://github.com/totallynotdavid/megaloader/tree/9adeffe2d4055d26f9db2b7fcbf6f92de0aca628)
+has been largely rewritten with my own opinionade ideas. My focus is on the
+following plugins (Bunkr, PixelDrain, Cyberdrop, and GoFile, which I decided to
+call core) while providing best-effort support for the extended set.
 
-If you want to contribute, you can either make a pull request to patch an error in a Megaloader's plugin, or create yours which I just have to validate before merging.
-If you're facing any error, please, open an issue.
+> [!TIP] If you encounter issues with any plugin, please report them through the
+> [GitHub Issues](https://github.com/totallynotdavid/megaloader/issues) tracker.
+> Include specific URLs, error messages (logs with DEBUG), and your Python
+> version for faster troubleshooting.
+
+## Understanding the architecture
+
+The package has a plugin-based architecture. Each supported platform is
+implemented as a separate plugin that inherits from a `BasePlugin` abstract base
+class.
+
+Every plugin implements two methods:
+
+- `export()` - Parses platform-specific pages and extracts file information
+- `download_file()` - Handles the actual file retrieval and storage
+
+An `Item` dataclass is used to pass information between these operations. See
+[megaloader/plugin.py](megaloader/plugin.py?plain=1#L7):
+
+```python
+@dataclass
+class Item:
+    url: str                                   # Direct download URL
+    filename: str                              # Suggested filename
+    album_title: Optional[str] = None          # Album/collection name
+    file_id: Optional[str] = None              # Platform-specific ID
+    metadata: Optional[dict[str, Any]] = None  # Additional platform data
+```
+
+### Advanced usage
+
+Some plugins support additional configuration options.
+
+For example, PixelDrain has an additional `use_proxy` option which lets you use
+a list of proxies provided by [@sh13y](https://github.com/sh13y) via
+[Cloudflare workers](https://github.com/sh13y/pixeldrain-ratelimit-bypasser). Of
+course, this can help with rate limiting issues but the caveat is that you have
+to trust his code/deployments[^1]. This option is turned off by default.
+
+```python
+download(
+    "https://pixeldrain.com/l/nH4ZKt3b",
+    "./downloads",
+    use_proxy=True
+)
+```
+
+GoFile allows users to put a password to access their files/albums. The module
+support this via the password prop.
+
+```python
+download(
+    "https://gofile.io/d/protected_folder",
+    "./downloads",
+    password="secret123"
+)
+```
+
+For maximum control over the download process, you can import a specific plugin
+and use it. If you intend to provide a service using this package, you should
+handle rate limiting, caching, URL validation by yourself. This package is not
+designed for high stressed scenarios (for now).
+
+To use the plugin class, you can do something like this:
+
+```python
+from megaloader.plugins import Cyberdrop
+
+plugin = Cyberdrop("https://cyberdrop.me/a/album_id")
+
+# Extract all items first (useful for progress tracking)
+items = list(plugin.export())
+print(f"Found {len(items)} files to download")
+
+# Download with custom logic
+for i, item in enumerate(items):
+    print(f"Downloading {i+1}/{len(items)}: {item.filename}")
+    success = plugin.download_file(item, "./downloads/")
+    if not success:
+        print(f"Failed to download {item.filename}")
+```
+
+## How to contribute
+
+We welcome contributions whether you're fixing bugs, improving existing plugins,
+or adding support for new platforms.
+
+Our development workflow includes several automated tasks for code quality:
+
+```bash
+mise run fix     # Format code and apply safe automated fixes via ruff
+mise run mypy    # Run comprehensive type checking
+mise run export  # Update requirements.txt from pyproject.toml
+```
+
+All contributions must meet our automated CI pipeline requirements which include
+[type safety](.github/workflows/checks.yml) (you'll be fine if you pass
+`mise run mypy`), [code style](.github/workflows/checks.yml) (`mise run fix`)
+and [security](.github/workflows/codeql.yml) (codeql).
+
+### Creating new plugins
+
+When developing plugins for new platforms, follow these guidelines:
+
+1. **Inherit from BasePlugin** and implement both required methods
+2. **Register your plugin** in the domain registry for automatic detection. See
+   [plugins/**init**.py](megaloader/plugins/__init__.py)
+3. (Optional) **Try to follow existing patterns** for consistency with the
+   existing codebase
+
+Here's a minimal plugin template:
+
+```python
+class NewPlatformPlugin(BasePlugin):
+    def __init__(self, url: str, **kwargs: Any) -> None:
+        super().__init__(url, **kwargs)
+        # Initialize session, configure headers, etc.
+
+    def export(self) -> Generator[Item, None, None]:
+        # Parse the URL and extract file information
+        # Yield Item objects with download metadata
+        pass
+
+    def download_file(self, item: Item, output_dir: str) -> bool:
+        # Handle actual file download and storage
+        # Return success/failure status
+        return True
+```
+
+### Technical details
+
+**Dependencies**: The runtime has a minimal footprint with just three core
+dependencies - `requests` for HTTP operations, `beautifulsoup4` for HTML
+parsing, and `lxml` as the high-performance parser backend for `beautifulsoup4`.
+Development dependencies include `ruff` for code quality and `mypy` for type
+safety. The [requirements.txt](requirements.txt) has a more extensive list but
+includes dependencies of our dependencies.
+
+**Configuration**: The `pyproject.toml` serves as the central configuration
+file, while `mise.toml` provides development environment automation with exact
+tool versions and task orchestration. Both ruff and mypy are configured in
+pyproject.toml.
+
+## Getting help
+
+**Bug Reports**: Use our
+[GitHub Issues](https://github.com/totallynotdavid/megaloader/issues) tracker.
+Include Python version, complete error messages, and specific URLs that are
+failing.
+
+**Feature Requests**: Also through GitHub Issues. Describe your use case and the
+platform you'd like to see supported.
+
+**General Questions**: GitHub Discussions are appropriate for general questions
+about usage or architecture.
+
+Remember to include relevant technical details like your Python version,
+dependency versions (you can get this with `uv tree` if using UV), and complete
+stack traces when reporting issues. This information significantly speeds up the
+debugging process and helps us provide better support.
+
+[^1]:
+    The repo may not be the code deployed on the actual worker and could
+    introduce you to man in the middle attacks.

--- a/README.md
+++ b/README.md
@@ -50,19 +50,19 @@ We currently support 11 platforms with different maintenance priorities. Core
 platforms receive active development and feature updates, while extended
 platforms are maintained on a best-effort basis.
 
-| Platform    | Domain(s)                                        | Features                             | Priority |
-| ----------- | ------------------------------------------------ | ------------------------------------ | -------- |
-| Bunkr       | bunkr.si, bunkr.la, bunkr.is, bunkr.ru, bunkr.su | Albums, single files, API extraction | Core     |
-| PixelDrain  | pixeldrain.com                                   | Files, lists, proxy support          | Core     |
-| Cyberdrop   | cyberdrop.me, cyberdrop.to                       | Albums, galleries                    | Core     |
-| GoFile      | gofile.io                                        | Password-protected folders           | Core     |
-| Fanbox      | {creator}.fanbox.cc, fanbox.cc/@{creator}        | Creator content, authentication      | Extended |
-| Pixiv       | pixiv.net                                        | Artwork, user galleries              | Extended |
-| Rule34      | rule34.xxx                                       | Search results, posts                | Extended |
-| ThotsLife   | thotslife.com                                    | Albums, profiles                     | Extended |
-| ThotHub.VIP | thothub.vip                                      | Platform content                     | Extended |
-| ThotHub.TO  | thothub.to                                       | Platform content                     | Extended |
-| Fapello     | fapello.com                                      | Profile extraction                   | Extended |
+| Platform    | Domain(s)                                        | Features                                                                    | Priority |
+| ----------- | ------------------------------------------------ | --------------------------------------------------------------------------- | -------- |
+| Bunkr       | bunkr.si, bunkr.la, bunkr.is, bunkr.ru, bunkr.su | Albums, single files, API extraction                                        | Core     |
+| PixelDrain  | pixeldrain.com                                   | Files, lists, proxy support (see [this section](#pixeldrain-proxy-support)) | Core     |
+| Cyberdrop   | cyberdrop.me, cyberdrop.to                       | Albums, galleries                                                           | Core     |
+| GoFile      | gofile.io                                        | Password-protected folders (see [this section](#gofile-password-support))   | Core     |
+| Fanbox      | {creator}.fanbox.cc, fanbox.cc/@{creator}        | Creator content, authentication                                             | Extended |
+| Pixiv       | pixiv.net                                        | Artwork, user galleries                                                     | Extended |
+| Rule34      | rule34.xxx                                       | Search results, posts                                                       | Extended |
+| ThotsLife   | thotslife.com                                    | Albums, profiles                                                            | Extended |
+| ThotHub.VIP | thothub.vip                                      | Platform content                                                            | Extended |
+| ThotHub.TO  | thothub.to                                       | Platform content                                                            | Extended |
+| Fapello     | fapello.com                                      | Profile extraction                                                          | Extended |
 
 > [!NOTE]
 > Extended plugins work as of 2025/08/25 but may occasionally break

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ function or plugin constructor.
 
 PixelDrain includes an optional proxy system that can help bypass rate limiting.
 This feature uses proxies provided by [@sh13y](https://github.com/sh13y) via
-[Cloudflare workers](https://github.sh13y/pixeldrain-ratelimit-bypasser). The
+[Cloudflare Workers](https://github.sh13y/pixeldrain-ratelimit-bypasser). The
 proxy option is disabled by default since it requires trusting external
 infrastructure. You can use it like this:
 

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ platforms.
 
 The project uses a plugin-based architecture where each supported platform is
 implemented as a separate plugin inheriting from the `BasePlugin` abstract base
-class defined in [megaloader/plugin.py](megaloader/plugin.py).
+class defined in [megaloader/plugin.py](megaloader/plugin.py?plain=1#L18).
 
 Each plugin implements two core methods that handle the complete download
 workflow:

--- a/README.md
+++ b/README.md
@@ -50,19 +50,19 @@ We currently support 11 platforms with different maintenance priorities. Core
 platforms receive active development and feature updates, while extended
 platforms are maintained on a best-effort basis.
 
-| Platform    | Domain(s)                                        | Features                                                                    | Priority |
-| ----------- | ------------------------------------------------ | --------------------------------------------------------------------------- | -------- |
-| Bunkr       | bunkr.si, bunkr.la, bunkr.is, bunkr.ru, bunkr.su | Albums, single files, API extraction                                        | Core     |
-| PixelDrain  | pixeldrain.com                                   | Files, lists, proxy support (see [this section](#pixeldrain-proxy-support)) | Core     |
-| Cyberdrop   | cyberdrop.me, cyberdrop.to                       | Albums, galleries                                                           | Core     |
-| GoFile      | gofile.io                                        | Password-protected folders (see [this section](#gofile-password-support))   | Core     |
-| Fanbox      | {creator}.fanbox.cc, fanbox.cc/@{creator}        | Creator content, authentication                                             | Extended |
-| Pixiv       | pixiv.net                                        | Artwork, user galleries                                                     | Extended |
-| Rule34      | rule34.xxx                                       | Search results, posts                                                       | Extended |
-| ThotsLife   | thotslife.com                                    | Albums, profiles                                                            | Extended |
-| ThotHub.VIP | thothub.vip                                      | Platform content                                                            | Extended |
-| ThotHub.TO  | thothub.to                                       | Platform content                                                            | Extended |
-| Fapello     | fapello.com                                      | Profile extraction                                                          | Extended |
+| Platform    | Domain(s)                                        | Features                                                 | Priority |
+| ----------- | ------------------------------------------------ | -------------------------------------------------------- | -------- |
+| Bunkr       | bunkr.si, bunkr.la, bunkr.is, bunkr.ru, bunkr.su | Albums, single files, API extraction                     | Core     |
+| PixelDrain  | pixeldrain.com                                   | Files, lists, [proxy support](#pixeldrain-proxy-support) | Core     |
+| Cyberdrop   | cyberdrop.me, cyberdrop.to                       | Albums, galleries                                        | Core     |
+| GoFile      | gofile.io                                        | [Password-protected folders](#gofile-password-support)   | Core     |
+| Fanbox      | {creator}.fanbox.cc, fanbox.cc/@{creator}        | Creator content, authentication                          | Extended |
+| Pixiv       | pixiv.net                                        | Artwork, user galleries                                  | Extended |
+| Rule34      | rule34.xxx                                       | Search results, posts                                    | Extended |
+| ThotsLife   | thotslife.com                                    | Albums, profiles                                         | Extended |
+| ThotHub.VIP | thothub.vip                                      | Platform content                                         | Extended |
+| ThotHub.TO  | thothub.to                                       | Platform content                                         | Extended |
+| Fapello     | fapello.com                                      | Profile extraction                                       | Extended |
 
 > [!NOTE]
 > Extended plugins work as of 2025/08/25 but may occasionally break

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ cd megaloader
 
 <details>
 <summary>
-#### Standard pip installation
+Standard pip installation
 </summary>
 
 For users familiar with traditional Python package management, install
@@ -106,7 +106,7 @@ python -m pip install -r requirements.txt
 
 <details>
 <summary>
-#### Poetry installation
+Poetry installation
 </summary>
 
 After installing Poetry following their
@@ -121,7 +121,7 @@ poetry install
 
 <details>
 <summary>
-#### UV installation
+UV installation
 </summary>
 
 uv offers faster dependency resolution and installation than pip. After
@@ -136,9 +136,7 @@ uv install
 
 <details>
 <summary>
-
-#### Recommended: mise installation
-
+Recommended: mise installation
 </summary>
 
 I recommend mise for the most reliable setup experience across different

--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ platforms are maintained on a best-effort basis.
 | PixelDrain  | pixeldrain.com                                   | Files, lists, [proxy support](#pixeldrain-proxy-support) | Core     |
 | Cyberdrop   | cyberdrop.me, cyberdrop.to                       | Albums, galleries                                        | Core     |
 | GoFile      | gofile.io                                        | [Password-protected folders](#gofile-password-support)   | Core     |
-| Fanbox      | {creator}.fanbox.cc, fanbox.cc/@{creator}        | Creator content, authentication                          | Extended |
-| Pixiv       | pixiv.net                                        | Artwork, user galleries                                  | Extended |
-| Rule34      | rule34.xxx                                       | Search results, posts                                    | Extended |
-| ThotsLife   | thotslife.com                                    | Albums, profiles                                         | Extended |
-| ThotHub.VIP | thothub.vip                                      | Platform content                                         | Extended |
-| ThotHub.TO  | thothub.to                                       | Platform content                                         | Extended |
+| Fanbox      | {creator}.fanbox.cc, fanbox.cc/@{creator}        | Creator content, [authentication](.env.example)          | Extended |
+| Pixiv       | pixiv.net                                        | Artwork, user galleries, [authentication](.env.example)  | Extended |
+| Rule34      | rule34.xxx                                       | Search results (tags), posts                             | Extended |
+| ThotsLife   | thotslife.com                                    | Albums, blog posts                                       | Extended |
+| ThotHub.VIP | thothub.vip                                      | Videos, albums                                           | Extended |
+| ThotHub.TO  | thothub.to                                       | Videos, albums                                           | Extended |
 | Fapello     | fapello.com                                      | Profile extraction                                       | Extended |
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 This project will make you smile. Megaloader is a package written in Python to
 automate downloads from various file hosting and media platforms.
 
-> [!WARNING] Many supported platforms host adult content. This tool is designed
+> [!WARNING]
+> Many supported platforms host adult content. This tool is designed
 > for content creators and digital archivists who need to work with such
 > platforms.
 
@@ -56,7 +57,8 @@ maintenance priority:
 | ThotHub.TO  | thothub.to                                       | Platform content                     | Extended |
 | Fapello     | fapello.com                                      | Profile extraction                   | Extended |
 
-> [!NOTE] **Core** plugins receive active maintenance and feature development.
+> [!NOTE] 
+> **Core** plugins receive active maintenance and feature development.
 > **Extended** plugins are supported on a best-effort basis and may occasionally
 > break without immediate fixes as I don't personally use them. They all work as
 > of 2025/08/25
@@ -156,7 +158,8 @@ has been largely rewritten with my own opinionade ideas. My focus is on the
 following plugins (Bunkr, PixelDrain, Cyberdrop, and GoFile, which I decided to
 call core) while providing best-effort support for the extended set.
 
-> [!TIP] If you encounter issues with any plugin, please report them through the
+> [!TIP]
+> If you encounter issues with any plugin, please report them through the
 > [GitHub Issues](https://github.com/totallynotdavid/megaloader/issues) tracker.
 > Include specific URLs, error messages (logs with DEBUG), and your Python
 > version for faster troubleshooting.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ maintenance priority:
 | ThotHub.TO  | thothub.to                                       | Platform content                     | Extended |
 | Fapello     | fapello.com                                      | Profile extraction                   | Extended |
 
-> [!NOTE] 
+> [!NOTE]
 > **Core** plugins receive active maintenance and feature development.
+>
 > **Extended** plugins are supported on a best-effort basis and may occasionally
 > break without immediate fixes as I don't personally use them. They all work as
 > of 2025/08/25

--- a/README.md
+++ b/README.md
@@ -344,13 +344,9 @@ The runtime maintains a minimal dependency footprint with three core libraries:
 - `beautifulsoup4` provides HTML parsing capabilities, and
 - `lxml` serves as the high-performance parser backend.
 
-Development dependencies include:
-
-- `ruff` for code formatting and linting, plus
-- `mypy` for static type checking.
-
-The complete dependency tree is available in
-[requirements.txt](requirements.txt).
+Development dependencies include `ruff` for code formatting and
+linting, plus `mypy` for static type checking. The complete dependency tree is
+available in [requirements.txt](requirements.txt).
 
 Configuration management centralizes around [pyproject.toml](pyproject.toml),
 which contains settings for all tools including ruff, mypy, and packaging

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ uv install
 
 </details>
 
-<details>
-<summary open>
+<details open>
+<summary>
 <b>Recommended</b>: mise installation
 </summary>
 

--- a/README.md
+++ b/README.md
@@ -51,19 +51,19 @@ We currently support 11 platforms with different maintenance priorities. Core
 platforms receive active development and feature updates, while extended
 platforms are maintained on a best-effort basis.
 
-| Platform    | Domain(s)                                        | Supports                                                                    | Priority |
-| ----------- | ------------------------------------------------ | --------------------------------------------------------------------------- | -------- |
-| Bunkr       | bunkr.si, bunkr.la, bunkr.is, bunkr.ru, bunkr.su | Albums, single files                                                        | Core     |
-| PixelDrain  | pixeldrain.com                                   | Lists, single files, [proxy support](#pixeldrain-proxy-support)             | Core     |
-| Cyberdrop   | cyberdrop.me, cyberdrop.to                       | Albums, single files                                                        | Core     |
-| GoFile      | gofile.io                                        | Folders ([even password-protected](#gofile-password-support)), single files | Core     |
-| Fanbox      | {creator}.fanbox.cc, fanbox.cc/@{creator}        | Creator content, [authentication](.env.example)                             | Extended |
-| Pixiv       | pixiv.net                                        | Artworks, galleries, [authentication](.env.example)                         | Extended |
-| Rule34      | rule34.xxx                                       | Tags, posts, [API support](.env.example)                                    | Extended |
-| ThotsLife   | thotslife.com                                    | Albums, blog posts                                                          | Extended |
-| ThotHub.VIP | thothub.vip                                      | Videos, albums                                                              | Extended |
-| ThotHub.TO  | thothub.to                                       | Videos, albums                                                              | Extended |
-| Fapello     | fapello.com                                      | Model profiles                                                              | Extended |
+| Platform    | Domain(s)                                        | Supports                                                               | Priority |
+| ----------- | ------------------------------------------------ | ---------------------------------------------------------------------- | -------- |
+| Bunkr       | bunkr.si, bunkr.la, bunkr.is, bunkr.ru, bunkr.su | Albums, single files                                                   | Core     |
+| PixelDrain  | pixeldrain.com                                   | Lists, single files, [proxy support](#pixeldrain-proxy-support)        | Core     |
+| Cyberdrop   | cyberdrop.me, cyberdrop.to                       | Albums, single files                                                   | Core     |
+| GoFile      | gofile.io                                        | Folders ([password-protected](#gofile-password-support)), single files | Core     |
+| Fanbox      | {creator}.fanbox.cc, fanbox.cc/@{creator}        | Creator content, [authentication](.env.example)                        | Extended |
+| Pixiv       | pixiv.net                                        | Artworks, galleries, [authentication](.env.example)                    | Extended |
+| Rule34      | rule34.xxx                                       | Tags, posts, [API support](.env.example)                               | Extended |
+| ThotsLife   | thotslife.com                                    | Albums, blog posts                                                     | Extended |
+| ThotHub.VIP | thothub.vip                                      | Videos, albums                                                         | Extended |
+| ThotHub.TO  | thothub.to                                       | Videos, albums                                                         | Extended |
+| Fapello     | fapello.com                                      | Model profiles                                                         | Extended |
 
 <!-- prettier-ignore -->
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ git clone https://github.com/totallynotdavid/megaloader
 cd megaloader
 ```
 
-Then, pick your poison (you only need to follow one):
+Then, pick your poison (**you only need to follow one**):
 
 <details>
 <summary>

--- a/README.md
+++ b/README.md
@@ -51,19 +51,19 @@ We currently support 11 platforms with different maintenance priorities. Core
 platforms receive active development and feature updates, while extended
 platforms are maintained on a best-effort basis.
 
-| Platform    | Domain(s)                                        | Supports                                                                      | Priority |
-| ----------- | ------------------------------------------------ | ----------------------------------------------------------------------------- | -------- |
-| Bunkr       | bunkr.si, bunkr.la, bunkr.is, bunkr.ru, bunkr.su | Albums, single files                                                          | Core     |
-| PixelDrain  | pixeldrain.com                                   | Lists, single files, [proxy support](#pixeldrain-proxy-support)               | Core     |
-| Cyberdrop   | cyberdrop.me, cyberdrop.to                       | Albums, single files                                                          | Core     |
-| GoFile      | gofile.io                                        | Folders, single files, [password-protected folders](#gofile-password-support) | Core     |
-| Fanbox      | {creator}.fanbox.cc, fanbox.cc/@{creator}        | Creator content, [authentication](.env.example)                               | Extended |
-| Pixiv       | pixiv.net                                        | Single artworks, user galleries, [authentication](.env.example)               | Extended |
-| Rule34      | rule34.xxx                                       | Tags, posts, [API support](.env.example)                                      | Extended |
-| ThotsLife   | thotslife.com                                    | Albums, blog posts                                                            | Extended |
-| ThotHub.VIP | thothub.vip                                      | Videos, albums                                                                | Extended |
-| ThotHub.TO  | thothub.to                                       | Videos, albums                                                                | Extended |
-| Fapello     | fapello.com                                      | Model profiles                                                                | Extended |
+| Platform    | Domain(s)                                        | Supports                                                                    | Priority |
+| ----------- | ------------------------------------------------ | --------------------------------------------------------------------------- | -------- |
+| Bunkr       | bunkr.si, bunkr.la, bunkr.is, bunkr.ru, bunkr.su | Albums, single files                                                        | Core     |
+| PixelDrain  | pixeldrain.com                                   | Lists, single files, [proxy support](#pixeldrain-proxy-support)             | Core     |
+| Cyberdrop   | cyberdrop.me, cyberdrop.to                       | Albums, single files                                                        | Core     |
+| GoFile      | gofile.io                                        | Folders ([even password-protected](#gofile-password-support)), single files | Core     |
+| Fanbox      | {creator}.fanbox.cc, fanbox.cc/@{creator}        | Creator content, [authentication](.env.example)                             | Extended |
+| Pixiv       | pixiv.net                                        | Artworks, galleries, [authentication](.env.example)                         | Extended |
+| Rule34      | rule34.xxx                                       | Tags, posts, [API support](.env.example)                                    | Extended |
+| ThotsLife   | thotslife.com                                    | Albums, blog posts                                                          | Extended |
+| ThotHub.VIP | thothub.vip                                      | Videos, albums                                                              | Extended |
+| ThotHub.TO  | thothub.to                                       | Videos, albums                                                              | Extended |
+| Fapello     | fapello.com                                      | Model profiles                                                              | Extended |
 
 <!-- prettier-ignore -->
 > [!NOTE]


### PR DESCRIPTION
This patch rewrites and expands the `README.md` to improve onboarding, clarify supported platforms, and document advanced usage of the Megaloader project.

Key updates:

* Reworked introduction to explain purpose, plugin-based design, intended audience, and adult content warning.
* Added modern installation instructions for pip, poetry, uv, and recommended mise, including installation verification.
* Documented supported platforms in a table, highlighting core vs. extended support and platform-specific features.
* Expanded usage section with basic/advanced scenarios, configuration (PixelDrain proxy, GoFile password), and direct plugin usage.
* Added project background, maintenance priorities, and contribution guidelines with references to the contributing guide and GitHub resources.