### PR TITLE
chore(gh): add structured issue templates for bugs, features, and platform requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,68 @@
+name: bug report
+description: Report a bug or issue with megaloader
+title: '[bug]: '
+labels: ['bug']
+
+body:
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+      description: Which platform were you downloading from?
+      placeholder: 'Bunkr, PixelDrain, Cyberdrop, GoFile, etc.'
+    validations:
+      required: true
+
+  - type: textarea
+    id: url
+    attributes:
+      label: Problem URL(s)
+      description: The specific URL(s) causing issues
+      placeholder: 'Paste the exact URL(s) you were trying to download'
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: What went wrong and what did you expect?
+      placeholder: 'Description of the bug and expected behavior'
+    validations:
+      required: true
+
+  - type: textarea
+    id: error
+    attributes:
+      label: Error output
+      description: Full error message (enable DEBUG logging if possible)
+      placeholder: 'Paste complete error message and stack trace'
+      render: shell
+    validations:
+      required: false
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: '3.13.7'
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: OS
+      placeholder: 'Windows 11, macOS 14, Ubuntu 22.04'
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues for duplicates
+          required: true
+        - label: I tested with the latest version
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/totallynotdavid/megaloader/discussions
+    about: Ask questions and discuss ideas with the community
+  - name: Contributing guide
+    url: https://github.com/totallynotdavid/megaloader/blob/main/.github/CONTRIBUTING.md
+    about: Learn how to contribute to the project

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,32 @@
+name: feature request
+description: Suggest a new feature or enhancement
+title: '[feature]: '
+labels: ['enhancement']
+
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this solve?
+      placeholder: "Describe the problem or limitation you're facing"
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution
+      description: What would you like to see implemented?
+      placeholder: 'Describe your ideal solution'
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: How would you use this feature?
+      placeholder: 'Provide specific examples of usage'
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/new-platform.yml
+++ b/.github/ISSUE_TEMPLATE/new-platform.yml
@@ -1,0 +1,58 @@
+name: new platform support
+description: Request support for a new platform
+title: '[platform]: '
+labels: ['new platform', 'enhancement']
+
+body:
+  - type: input
+    id: platform-name
+    attributes:
+      label: Platform name
+    validations:
+      required: true
+
+  - type: input
+    id: domain
+    attributes:
+      label: Domain(s)
+      placeholder: 'example.com, alt-domain.net'
+    validations:
+      required: true
+
+  - type: textarea
+    id: urls
+    attributes:
+      label: Example URLs
+      description: Provide 2-3 working example URLs
+      placeholder: |
+        Album: https://{example}.com/album/123
+        Single file: https://{example}.com/file/456
+        Profile: https://{example}.com/user/name
+    validations:
+      required: true
+
+  - type: textarea
+    id: content-types
+    attributes:
+      label: Content types
+      description: What type of content does this platform host?
+      placeholder: 'Images, videos, documents, albums, etc.'
+    validations:
+      required: true
+
+  - type: textarea
+    id: authentication
+    attributes:
+      label: Authentication
+      description: Login requirements, API keys, or access restrictions?
+      placeholder: 'None / requires account / API key needed / etc.'
+    validations:
+      required: false
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Why do you need this?
+      placeholder: 'Explain your use case for this platform'
+    validations:
+      required: true


### PR DESCRIPTION
Introduce GitHub issue templates to standardize reporting and guide users toward proper contribution channels.

Changes include:

* Add `.github/ISSUE_TEMPLATE/bug-report.yml` for detailed bug reports (platform, URLs, errors, environment, checklist).
* Add `.github/ISSUE_TEMPLATE/feature-request.yml` for structured feature proposals (problem, solution, use cases).
* Add `.github/ISSUE_TEMPLATE/new-platform.yml` for platform support requests (domains, example URLs, content type, auth, motivation).
* Add `.github/ISSUE_TEMPLATE/config.yml` to disable blank issues and link to discussions/contributing docs.