### PR TITLE
chore(templates): standardize capitalization and tone in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,5 +1,5 @@
 name: bug report
-description: Report a bug or issue with megaloader
+description: report a bug or issue
 title: '[bug]: '
 labels: ['bug']
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,9 +1,9 @@
 blank_issues_enabled: false
 
 contact_links:
-  - name: GitHub Discussions
+  - name: github discussions
     url: https://github.com/totallynotdavid/megaloader/discussions
-    about: Ask questions and discuss ideas with the community
-  - name: Contributing guide
+    about: ask questions and discuss ideas with the community
+  - name: contributing guide
     url: https://github.com/totallynotdavid/megaloader/blob/main/.github/CONTRIBUTING.md
-    about: Learn how to contribute to the project
+    about: learn how to contribute to the project

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,5 +1,5 @@
 name: feature request
-description: Suggest a new feature or enhancement
+description: suggest a new feature or enhancement
 title: '[feature]: '
 labels: ['enhancement']
 

--- a/.github/ISSUE_TEMPLATE/new-platform.yml
+++ b/.github/ISSUE_TEMPLATE/new-platform.yml
@@ -1,5 +1,5 @@
 name: new platform support
-description: Request support for a new platform
+description: request support for a new platform
 title: '[platform]: '
 labels: ['new platform', 'enhancement']
 


### PR DESCRIPTION
This patch makes small improvements to the GitHub issue templates by aligning capitalization, tone, and contact link descriptions.