### PR TITLE
feat(docs): add API demo component with frontend and backend support

### DIFF
--- a/api/downloads.py
+++ b/api/downloads.py
@@ -46,11 +46,17 @@ def download_file(item: DownloadItem, output_dir: Path) -> Path | None:
 
         logger.debug("Starting download", extra={"file_name": item.filename})
 
+        headers = item.headers.copy()
+        if "User-Agent" not in headers:
+            headers["User-Agent"] = (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+            )
+
         response = requests.get(
             item.download_url,
             stream=True,
             timeout=DOWNLOAD_TIMEOUT,
-            headers=item.headers,
+            headers=headers,
         )
         response.raise_for_status()
 

--- a/api/main.py
+++ b/api/main.py
@@ -44,6 +44,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["GET", "POST"],
     allow_headers=["*"],
+    expose_headers=["Content-Disposition"],
 )
 
 

--- a/docs/megaloader/.vitepress/theme/index.ts
+++ b/docs/megaloader/.vitepress/theme/index.ts
@@ -2,6 +2,7 @@
 import { h } from "vue";
 import type { Theme } from "vitepress";
 import DefaultTheme from "vitepress/theme";
+import ApiDemo from "../../components/api-demo.vue";
 import "./style.css";
 
 export default {
@@ -12,6 +13,6 @@ export default {
     });
   },
   enhanceApp({ app, router, siteData }) {
-    // ...
+    app.component("ApiDemo", ApiDemo);
   },
 } satisfies Theme;

--- a/docs/megaloader/.vitepress/vue-shim.d.ts
+++ b/docs/megaloader/.vitepress/vue-shim.d.ts
@@ -1,0 +1,5 @@
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+  const component: DefineComponent<{}, {}, any>;
+  export default component;
+}

--- a/docs/megaloader/components/api-demo.vue
+++ b/docs/megaloader/components/api-demo.vue
@@ -1,0 +1,211 @@
+<template>
+  <div class="api-demo">
+    <div class="input-group">
+      <input 
+        id="url-input" 
+        v-model="url" 
+        type="url" 
+        placeholder="https://pixeldrain.com/u/..."
+        @keyup.enter="startDownload" 
+        :disabled="isDownloading"
+      />
+      <button 
+        class="download-btn" 
+        @click="startDownload" 
+        :disabled="!url.trim() || isDownloading"
+      >
+        <span v-if="isDownloading" class="spinner"></span>
+        {{ isDownloading ? 'Processing...' : 'Download' }}
+      </button>
+    </div>
+    
+    <div class="demo-limits">
+      Demo limits: Max 4MB file size • Max 50 files
+    </div>
+
+    <ToastContainer :toasts="toasts" />
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+import ToastContainer from "./toast-container.vue";
+
+const props = defineProps({
+  apiUrl: {
+    type: String,
+    default: import.meta.env.VITE_API_URL || "http://localhost:8000",
+  },
+});
+
+const url = ref("");
+const isDownloading = ref(false);
+const toasts = ref([]);
+let toastId = 0;
+
+const showToast = (message, type = "info") => {
+  const id = toastId++;
+  toasts.value.push({ id, message, type });
+  setTimeout(() => {
+    toasts.value = toasts.value.filter((t) => t.id !== id);
+  }, 5000);
+};
+
+const startDownload = async () => {
+  if (!url.value.trim() || isDownloading.value) return;
+
+  isDownloading.value = true;
+
+  try {
+    const endpoint = `${props.apiUrl.replace(/\/$/, "")}/download`;
+
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        url: url.value.trim(),
+      }),
+    });
+
+    const contentType = response.headers.get("content-type");
+
+    if (response.ok) {
+      if (contentType?.includes("application/json")) {
+        const data = await response.json();
+        if (data.exceeds_limit) {
+          showToast(data.message || "File too large for demo server", "error");
+        } else {
+          showToast("Request successful", "success");
+        }
+      } else {
+        const blob = await response.blob();
+        const downloadUrl = window.URL.createObjectURL(blob);
+
+        // Try to get filename from Content-Disposition header
+        const contentDisposition = response.headers.get("content-disposition");
+        let filename = "download.zip";
+
+        if (contentDisposition) {
+          // Handle both filename="name" and filename*=UTF-8''name formats
+          const filenameRegex = /filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/;
+          const matches = filenameRegex.exec(contentDisposition);
+          if (matches != null && matches[1]) {
+            filename = matches[1].replace(/['"]/g, "");
+          }
+        }
+
+        const a = document.createElement("a");
+        a.href = downloadUrl;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        window.URL.revokeObjectURL(downloadUrl);
+        document.body.removeChild(a);
+
+        showToast(`Downloaded ${filename} successfully!`, "success");
+        url.value = ""; // Clear input on success
+      }
+    } else {
+      let errorMessage = "Download failed";
+      try {
+        const data = await response.json();
+        errorMessage = data.detail || errorMessage;
+      } catch (e) {
+        // Ignore JSON parse error
+      }
+      showToast(errorMessage, "error");
+    }
+  } catch (err) {
+    console.error(err);
+    showToast("Failed to connect to download service", "error");
+  } finally {
+    isDownloading.value = false;
+  }
+};
+</script>
+
+<style scoped>
+.api-demo {
+  margin: 1rem 0;
+  position: relative;
+}
+
+.input-group {
+  display: flex;
+  gap: 0.5rem;
+}
+
+#url-input {
+  flex: 1;
+  padding: 0.6rem 1rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  font-size: 0.9rem;
+  background: var(--vp-c-bg-alt);
+  color: var(--vp-c-text-1);
+  transition: border-color 0.2s, box-shadow 0.2s;
+  font-family: var(--vp-font-family-mono);
+}
+
+#url-input:focus {
+  outline: none;
+  border-color: var(--vp-c-brand);
+  box-shadow: 0 0 0 2px var(--vp-c-brand-dimm);
+}
+
+#url-input:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.download-btn {
+  padding: 0.6rem 1.2rem;
+  background: var(--vp-c-brand);
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  white-space: nowrap;
+}
+
+.download-btn:hover:not(:disabled) {
+  filter: brightness(0.9);
+}
+
+.download-btn:disabled {
+  background: var(--vp-c-bg-soft);
+  color: var(--vp-c-text-3);
+  cursor: not-allowed;
+}
+
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(255,255,255,0.3);
+  border-radius: 50%;
+  border-top-color: white;
+  animation: spin 1s linear infinite;
+}
+
+.demo-limits {
+  margin-top: 0.5rem;
+  font-size: 0.8rem;
+  color: var(--vp-c-text-2);
+  text-align: right;
+}
+
+@media (max-width: 640px) {
+  .input-group {
+    flex-direction: column;
+  }
+}
+</style>

--- a/docs/megaloader/components/toast-container.vue
+++ b/docs/megaloader/components/toast-container.vue
@@ -1,0 +1,84 @@
+<template>
+  <TransitionGroup name="toast" tag="div" class="toast-container">
+    <div 
+      v-for="toast in toasts" 
+      :key="toast.id" 
+      class="toast" 
+      :class="toast.type"
+    >
+      <span class="toast-icon">{{ toast.type === 'success' ? '✓' : '!' }}</span>
+      {{ toast.message }}
+    </div>
+  </TransitionGroup>
+</template>
+
+<script setup>
+defineProps({
+  toasts: {
+    type: Array,
+    required: true,
+  },
+});
+</script>
+
+<style scoped>
+.toast-container {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  z-index: 100;
+  pointer-events: none;
+}
+
+.toast {
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  background: var(--vp-c-bg);
+  border: 1px solid var(--vp-c-divider);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.9rem;
+  pointer-events: auto;
+  max-width: 350px;
+}
+
+.toast.success {
+  border-left: 4px solid var(--vp-c-green);
+}
+
+.toast.error {
+  border-left: 4px solid var(--vp-c-red);
+}
+
+.toast-icon {
+  font-weight: bold;
+}
+
+.toast.success .toast-icon { color: var(--vp-c-green); }
+.toast.error .toast-icon { color: var(--vp-c-red); }
+
+/* Toast Transitions */
+.toast-enter-active,
+.toast-leave-active {
+  transition: all 0.3s ease;
+}
+
+.toast-enter-from,
+.toast-leave-to {
+  opacity: 0;
+  transform: translateY(20px);
+}
+
+@media (max-width: 640px) {
+  .toast-container {
+    left: 1rem;
+    right: 1rem;
+    bottom: 1rem;
+  }
+}
+</style>

--- a/docs/megaloader/guide/getting-started.md
+++ b/docs/megaloader/guide/getting-started.md
@@ -4,6 +4,12 @@ Megaloader extracts file metadata from hosting platforms (like PixelDrain,
 GoFile or Bunkr). It gives you direct download URLs, filenames, and any required
 headers. You choose what to download and how to handle the requests.
 
+## Live demo
+
+You can try the API directly in your browser to see how it works. The implementation is available in the [/api/](https://github.com/totallynotdavid/megaloader/tree/main/api) folder of the repo and is deployed via Vercel.
+
+<ApiDemo />
+
 ## Requirements
 
 Megaloader requires Python 3.10 or higher and can be installed with pip, uv, or


### PR DESCRIPTION
Changes:

* Add `ApiDemo` Vue component for testing downloads in-browser, including input validation and toast notifications.
* Register `ApiDemo` globally in VitePress theme and embed it in the Getting Started guide.
* Add reusable `ToastContainer` component for success and error messages.
* Backend updates: expose `Content-Disposition` header via CORS middleware and ensure default `User-Agent` for outgoing downloads to improve compatibility.